### PR TITLE
Description of complexity is inaccurate for Union Find data structure

### DIFF
--- a/union-find.cpp
+++ b/union-find.cpp
@@ -27,10 +27,28 @@
 
 struct UnionFind {
   int pset[MAXN];
+  int rank[MAXN];
 
-  void init(int n) { for(int i = 0; i < n; i++) pset[i] = i; }
+  void init(int n) { 
+    for(int i = 0; i < n; i++) {
+      pset[i] = i;
+      rank[i] = 0; 
+    }
+  }
   int get(int i) { return (pset[i] == i) ? i : (pset[i] = get(pset[i])); }
-  void join(int i, int j) { pset[get(i)] = get(j); }
+  void join(int i, int j) {
+    int xRoot = get(i);
+    int yRoot = get(j);
+    if (xRoot == yRoot) return;
+    if (rank[xRoot] < rank[yRoot])
+      pset[xRoot] = yRoot;
+    else if (rank[xRoot] > rank[yRoot])
+      pset[yRoot] = xRoot;
+    else {
+      pset[yRoot] = xRoot;
+      rank[xRoot] = rank[xRoot] + 1;
+    }
+  }
   bool sameSet(int i, int j) { return get(i) == get(j); }
 };
 


### PR DESCRIPTION
Added union by rank to the join() operations to make for description accurate. As previously written you code has: O((m+n) log n).
The union-find data structure with path compression but without union by rank processes m find and n-1 link operations in time O((m+n) log n).
https://books.google.ru/books?id=oK3UWxg_UhsC&pg=PA224&lpg=PA224&dq=%22without+union+by+rank%22&source=bl&ots=iGGO7XKp6L&sig=U76thEmxJZ4oadMQPRbW8sA9tDI&hl=ru&ei=PDeFS5OFNJPw-QbQxIyeAQ&sa=X&oi=book_result&ct=result#v=onepage&q=%22without%20union%20by%20rank%22&f=false
